### PR TITLE
Add tool to retry migration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     'google-auth',
     'google-cloud-core',
     'google-cloud-monitoring',
-    'google-cloud-trace',
+    'google-cloud-trace >= 0.20.0, < 1.0.0',
     'googleapis-common-protos',
     'grpcio',
     'idna',
@@ -40,6 +40,7 @@ requirements = [
     'urllib3',
     'google.cloud.logging',
     'python-i18n[YAML]',
+    'alembic',
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/styler_rest_framework/helpers/migration.py
+++ b/styler_rest_framework/helpers/migration.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import time
+from random import randint
+
+from alembic.config import Config
+from alembic import command
+
+
+class MigrationError(Exception):
+    """MigrationError class for exceptions in this module."""
+    pass
+
+
+def get_current_version(alembic_cfg):
+    captured_text = None
+
+    def print_stdout(text, *arg):
+        nonlocal captured_text
+        captured_text = text
+
+    alembic_cfg.print_stdout = print_stdout
+    command.current(alembic_cfg)
+    return captured_text
+
+
+def get_heads_version(alembic_cfg):
+    captured_text = []
+
+    def print_stdout(text, *arg):
+        nonlocal captured_text
+        captured_text.append(text)
+    alembic_cfg.print_stdout = print_stdout
+    command.heads(alembic_cfg)
+    return captured_text
+
+
+def retry_migration(alembic_cfg, count, max_count, max_backoff=32):
+    try:
+        logging.warning(f'retry migration now... (retry count:{count+1})')
+        command.upgrade(alembic_cfg, 'head')
+        logging.warning('retry migration succeed!')
+        return
+    except Exception:
+        backoff = min(2**(count)+randint(1, 1000)/1000, max_backoff)
+        count += 1
+        if count >= max_count:
+            raise MigrationError('Could not execute alembic migrations.')
+        logging.warning(f'retry migration failed, \
+            will retry again after {backoff} seconds...')
+        time.sleep(backoff)
+        retry_migration(alembic_cfg, count, max_count, max_backoff)
+
+
+def check_and_retry_migration(max_retry_count=3):
+    cfg_path = os.path.join(os.path.dirname(__file__), 'alembic.ini')
+    alembic_cfg = Config(cfg_path)
+    heads = get_heads_version(alembic_cfg)
+    if len(heads) > 1:
+        raise MigrationError(f'multiple heads detected! {heads}')
+    current = get_current_version(alembic_cfg)
+    if current == heads[0]:
+        return
+    logging.warning('alembic version is not up-to-date, \
+        will retry migration...')
+    retry_migration(alembic_cfg, 0, max_retry_count)
+
+
+if __name__ == '__main__':
+    check_and_retry_migration()

--- a/tests/helpers/test_migration.py
+++ b/tests/helpers/test_migration.py
@@ -1,0 +1,69 @@
+""" Tests for the Migration tools
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from styler_rest_framework.helpers import migration
+
+
+class TestCheckAndRetryMigration:
+    """ Tests for check_and_retry_migration
+    """
+    def test_version_up_to_date(self):
+        """ It should return without errors
+        """
+        migration.get_heads_version = Mock(return_value=['head'])
+        migration.get_current_version = Mock(return_value='head')
+
+        migration.check_and_retry_migration()
+
+        migration.get_heads_version.assert_called_once()
+        migration.get_current_version.assert_called_once()
+
+    def test_multiple_head(self):
+        """ It should raise migration error
+        """
+        migration.get_heads_version = Mock(return_value=['head1', 'head2'])
+        migration.get_current_version = Mock(return_value='head')
+
+        with pytest.raises(migration.MigrationError) as expected:
+            migration.check_and_retry_migration()
+
+        assert "multiple heads detected!" in str(expected.value)
+
+        migration.get_heads_version.assert_called_once()
+
+    @patch('alembic.command.upgrade')
+    @patch('logging.warning')
+    def test_retry_success(self, log_mock, upgrade_mock):
+        """ It should return without errors
+        """
+        migration.get_heads_version = Mock(return_value=['head'])
+        migration.get_current_version = Mock(return_value='old_version')
+
+        migration.check_and_retry_migration()
+
+        migration.get_heads_version.assert_called_once()
+        migration.get_current_version.assert_called_once()
+        upgrade_mock.assert_called_once()
+        log_mock.assert_any_call('alembic version is not up-to-date, \
+        will retry migration...')
+
+    @patch('logging.warning')
+    def test_retry_failed(self, log_mock):
+        """ It should return without errors
+        """
+        migration.get_heads_version = Mock(return_value=['head'])
+        migration.get_current_version = Mock(return_value='old_version')
+
+        with patch('alembic.command.upgrade',
+                   side_effect=Exception()) as upgrade_mock:
+            with pytest.raises(migration.MigrationError) as expected:
+                migration.check_and_retry_migration(max_retry_count=3)
+
+            migration.get_heads_version.assert_called_once()
+            migration.get_current_version.assert_called_once()
+            assert 3 == upgrade_mock.call_count
+            assert "Could not execute alembic migrations." in str(
+                expected.value)

--- a/tests/helpers/test_migration.py
+++ b/tests/helpers/test_migration.py
@@ -52,7 +52,7 @@ class TestCheckAndRetryMigration:
 
     @patch('logging.warning')
     def test_retry_failed(self, log_mock):
-        """ It should return without errors
+        """ It should raise migration error
         """
         migration.get_heads_version = Mock(return_value=['head'])
         migration.get_current_version = Mock(return_value='old_version')


### PR DESCRIPTION
## Topic
Add tool to retry migration if it failed first time.

## Detail
* add dependency `alembic` and fix google-cloud-trace issue by limit the version as 'google-cloud-trace >= 0.20.0, < 1.0.0'
* add retry migration logic.
* add tests.