### PR TITLE
Adding defaults and changing the service name in error reporting

### DIFF
--- a/styler_rest_framework/config/__init__.py
+++ b/styler_rest_framework/config/__init__.py
@@ -1,0 +1,2 @@
+""" This module holds the logic to standard configurations in all modules
+"""

--- a/styler_rest_framework/config/defaults.py
+++ b/styler_rest_framework/config/defaults.py
@@ -1,0 +1,10 @@
+""" Defaults used by all modules
+"""
+
+import os
+
+
+SERVICE_NAME = os.getenv('SERVICE_NAME') or 'svc'
+CONTAINER_NAME = os.getenv('SERVICE_NAME') or 'container'
+
+ERROR_HANDLER_SERVICE = f'{CONTAINER_NAME}/{SERVICE_NAME}'

--- a/styler_rest_framework/helpers/aiohttp_defaults.py
+++ b/styler_rest_framework/helpers/aiohttp_defaults.py
@@ -4,6 +4,7 @@
 import logging
 
 from styler_middleware import handle_exceptions, handle_invalid_json
+from styler_rest_framework.config import defaults
 from styler_rest_framework.logging import setup_logging
 from styler_rest_framework.logging.error_reporting import (
     google_error_reporting_handler
@@ -12,8 +13,9 @@ from styler_rest_framework.logging.error_reporting import (
 
 def api_error_reporting_handler(service=None):  # pragma: no coverage
     try:
+        service_name = service or defaults.ERROR_HANDLER_SERVICE
         from google.cloud import error_reporting
-        handler = google_error_reporting_handler(service=service)
+        handler = google_error_reporting_handler(service=service_name)
 
         def error_handler(request, exc):
             http_context = error_reporting.HTTPContext(

--- a/styler_rest_framework/logging/error_reporting.py
+++ b/styler_rest_framework/logging/error_reporting.py
@@ -2,11 +2,14 @@
 """
 import logging
 
+from styler_rest_framework.config import defaults
+
 
 def google_error_reporting_handler(service=None):  # pragma: no coverage
     try:
+        service_name = service or defaults.ERROR_HANDLER_SERVICE
         from google.cloud import error_reporting
-        client = error_reporting.Client(service=service)
+        client = error_reporting.Client(service=service_name)
         return client.report_exception
 
     except Exception:

--- a/styler_rest_framework/pubsub/__init__.py
+++ b/styler_rest_framework/pubsub/__init__.py
@@ -6,6 +6,7 @@ import json
 import logging
 
 from styler_rest_framework.logging import error_reporting
+from styler_rest_framework.config import defaults
 
 
 class MessageRouter:
@@ -15,7 +16,8 @@ class MessageRouter:
     def __init__(self, error_handler=None):
         self._routes = {}
         self.error_handler = error_handler or \
-            error_reporting.google_error_reporting_handler()
+            error_reporting.google_error_reporting_handler(
+                service=defaults.ERROR_HANDLER_SERVICE)
 
     def handle_message(self, message: Any) -> None:
         """ Route the incoming messages


### PR DESCRIPTION
## Purpose
- Adding `defaults` module to hold default configuration shared among all modules.
- Changing the default service name of error reporting.