### PR TITLE
Revert logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = [
     'rsa',
     'six',
     'urllib3',
-    'google.cloud.logging',
+    'google-cloud-logging < 2.0.0',
     'python-i18n[YAML]',
     'alembic',
     'fastapi',


### PR DESCRIPTION
## Purpose
The new google cloud logging 2.0.0 is breaking the current logging. This will set back to the 1.15 version.