### PR TITLE
STYLER-1449: Move GCS handler into Styler Rest Framework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requirements = [
     'google-cloud-core',
     'google-cloud-monitoring',
     'google-cloud-pubsub',
+    'google-cloud-storage',
     'google-cloud-trace >= 0.20.0, < 1.0.0',
     'googleapis-common-protos',
     'grpcio',

--- a/styler_rest_framework/helpers/gcs_handler.py
+++ b/styler_rest_framework/helpers/gcs_handler.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""This is the class of handling google cloud storage"""
+
+from io import StringIO
+import time
+
+from google.cloud import storage
+from google.api_core.exceptions import ServiceUnavailable
+
+
+class GCSHandler:
+    """The handler of google cloud storage (GCS)
+
+    Args:
+        bucket_name (str): target bucket name of gs
+        *args: placeholder
+        **kwargs: placeholder
+
+    Attributes:
+        bucket : a gs bucket instance
+    """
+
+    def __init__(self, bucket_name, *args, **kwargs):
+        client = storage.Client()
+        self.bucket = client.get_bucket(bucket_name)
+        self._BACKOFF = kwargs.get("back_off", 3)
+
+    def get_files_from_folder(self, folder_name, retry=3):
+        """Return an iterator used to find blobs in the bucket.
+
+        Args:
+            folder_name (str): folder name or prefix path
+
+        Returns:
+            an iterator used to find blobs in the bucket
+        """
+        try:
+            return self.bucket.list_blobs(prefix=folder_name)
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.get_files_from_folder(folder_name, retry=retry - 1)
+            else:
+                raise
+
+    def download_file_as_string_with_formatter(self, file_path, retry=3):
+        """Download the contents of this blob as a bytes object.
+
+        Args:
+            file_path (str): path of file
+
+        Returns:
+            The data stored in this blob.
+        """
+        try:
+            blob = self.bucket.blob(file_path)
+            return blob.download_as_string().decode("utf-8").splitlines()
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.download_file_as_string_with_formatter(
+                    file_path, retry=retry - 1
+                )
+            else:
+                raise
+
+    def download_file_as_stream(self, file_path, retry=3):
+        """Download the contents of this blob as a StringIO object.
+
+        Args:
+            file_path (str): path of file
+
+        Returns:
+            The data stored in this blob.
+        """
+        try:
+            blob = self.bucket.blob(file_path)
+            return StringIO(blob.download_as_bytes().decode("utf-8"))
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.download_file_as_stream(file_path, retry=retry - 1)
+            else:
+                raise
+
+    def download_file_as_string(self, file_path, retry=3):
+        """Download the contents of this blob as a bytes object.
+
+        Args:
+            file_path (str): path of file
+
+        Returns:
+            The data stored in this blob.
+        """
+        try:
+            blob = self.bucket.blob(file_path)
+            return blob.download_as_string()
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.download_file_as_string(file_path, retry=retry - 1)
+            else:
+                raise
+
+    def upload_file(self, file_obj, file_name, retry=3):
+        """upload a file to the bucket.
+
+        Args:
+            file_obj (file object): A file handle open for reading.
+            file_name (str): file name
+
+        Raises:
+            GoogleCloudError if the upload response returns an error status.
+        """
+        try:
+            blob = self.bucket.blob(file_name)
+            return blob.upload_from_file(file_obj)
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.upload_file(file_obj, file_name, retry=retry - 1)
+            else:
+                raise
+
+    def rename_file(self, old_file_name, new_file_name, retry=3):
+        """rename a file from the bucket.
+
+        Args:
+            old_file_name (str): old file name
+            new_file_name (str): new file name
+
+        Raises:
+            GoogleCloudError if the upload response returns an error status.
+        """
+        try:
+            blob = self.bucket.blob(old_file_name)
+            return self.bucket.rename_blob(blob, new_file_name)
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.rename_file(old_file_name, new_file_name, retry=retry - 1)
+            else:
+                raise
+
+    def put_as_string(
+        self, filename: str, file_string: bytes, content_type: str, retry=3
+    ):
+        """Method to upload objects."""
+        try:
+            blob = self.bucket.blob(filename)
+            return blob.upload_from_string(file_string, content_type)
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.put_as_string(
+                    filename, file_string, content_type, retry=retry - 1
+                )
+            else:
+                raise
+
+    def delete_file(self, filename, retry=3):
+        """Deletes a file from the bucket"""
+        try:
+            blob = self.bucket.blob(filename)
+            return blob.delete()
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.delete_file(filename, retry=retry - 1)
+            else:
+                raise
+
+    def is_exist(self, filename, retry=3):
+        """Check if a file exists in the bucket"""
+        try:
+            blob = self.bucket.blob(filename)
+            return blob.exists()
+        except ServiceUnavailable:
+            if retry > 0:
+                time.sleep(self._BACKOFF)
+                return self.is_exist(filename, retry=retry - 1)
+            else:
+                raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,3 +64,8 @@ def token():
 @pytest.fixture
 def empty_token():
     return jwt.encode({}, 'secret-key')
+
+
+@pytest.fixture
+def csv_blob_from_gcs():
+    return 'header1,header2\nrow1-1,row1-2'.encode('utf-8')

--- a/tests/helpers/test_gcs_handler.py
+++ b/tests/helpers/test_gcs_handler.py
@@ -1,0 +1,481 @@
+"""Tests for GCSHandler
+"""
+from unittest.mock import MagicMock, patch
+import pytest
+
+from google.api_core.exceptions import ServiceUnavailable
+
+from styler_rest_framework.helpers.gcs_handler import GCSHandler
+
+
+class TestGetFilesFromFolder:
+    """Tests for function get_files_from_folder"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.list_blobs.return_value = "test return"
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.get_files_from_folder("test_folder")
+        assert result == "test return"
+        mock_bucket.list_blobs.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.list_blobs.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            "test return",
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.get_files_from_folder("test_folder")
+        assert result == "test return"
+        assert mock_bucket.list_blobs.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.list_blobs.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.get_files_from_folder("test_folder")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestDownloadFileAsStringWithFormatter:
+    """Tests for function download_file_as_string_with_formatter"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.return_value = csv_blob_from_gcs
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.download_file_as_string_with_formatter("test_file_path")
+        assert len(result) == 2
+        assert result[0] == "header1,header2"
+        assert result[1] == "row1-1,row1-2"
+        mock_bucket.blob.assert_called_once()
+        mock_blob.download_as_string.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            csv_blob_from_gcs,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.download_file_as_string_with_formatter("test_file_path")
+        assert len(result) == 2
+        assert result[0] == "header1,header2"
+        assert result[1] == "row1-1,row1-2"
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.download_as_string.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.download_file_as_string_with_formatter("test_file_path")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestDownloadFileAsStream:
+    """Tests for function download_file_as_stream"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_bytes.return_value = csv_blob_from_gcs
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.download_file_as_stream("test_file_path")
+        assert result.getvalue() == csv_blob_from_gcs.decode("utf-8")
+        mock_bucket.blob.assert_called_once()
+        mock_blob.download_as_bytes.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_bytes.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            csv_blob_from_gcs,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.download_file_as_stream("test_file_path")
+        assert result.getvalue() == csv_blob_from_gcs.decode("utf-8")
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.download_as_bytes.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_bytes.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.download_file_as_stream("test_file_path")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestDownloadFileAsString:
+    """Tests for function download_file_as_string"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.return_value = csv_blob_from_gcs
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.download_file_as_string("test_file_path")
+        assert result == csv_blob_from_gcs
+        mock_bucket.blob.assert_called_once()
+        mock_blob.download_as_string.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs, csv_blob_from_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            csv_blob_from_gcs,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.download_file_as_string("test_file_path")
+        assert result == csv_blob_from_gcs
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.download_as_string.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.download_file_as_string("test_file_path")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestUploadFile:
+    """Tests for function upload_file"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_file.return_value = True
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.upload_file("test_file_obj", "test_file_path")
+        assert result is True
+        mock_bucket.blob.assert_called_once()
+        mock_blob.upload_from_file.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_file.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            True,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.upload_file("test_file_obj", "test_file_path")
+        assert result is True
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.upload_from_file.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_file.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.upload_file("test_file_obj", "test_file_path")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestRenameFile:
+    """Tests for function rename_file"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.rename_blob.return_value = True
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.rename_file("old_file_name", "new_file_name")
+        assert result is True
+        mock_bucket.blob.assert_called_once()
+        mock_bucket.rename_blob.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.rename_blob.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            True,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.rename_file("old_file_name", "new_file_name")
+        assert result is True
+        assert mock_bucket.blob.call_count == 2
+        assert mock_bucket.rename_blob.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_bucket.rename_blob.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.rename_file("old_file_name", "new_file_name")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestPutAsString:
+    """Tests for function put_as_string"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_string.return_value = True
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.put_as_string(
+            "test_file_name", "test_file_string", "test_content_type"
+        )
+        assert result is True
+        mock_bucket.blob.assert_called_once()
+        mock_blob.upload_from_string.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            True,
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.put_as_string(
+            "test_file_name", "test_file_string", "test_content_type"
+        )
+        assert result is True
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.upload_from_string.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.upload_from_string.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.put_as_string(
+                "test_file_name", "test_file_string", "test_content_type"
+            )
+            assert expected.value.errors == "service unavailable"
+
+
+class TestDeleteFile:
+    """Tests for function delete_file"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.delete.return_value = True
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.delete_file("test_file_name")
+        assert result is True
+        mock_bucket.blob.assert_called_once()
+        mock_blob.delete.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.delete.side_effect = [ServiceUnavailable("service unavailable"), True]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.delete_file("test_file_name")
+        assert result is True
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.delete.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.delete.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.delete_file("test_file_name")
+            assert expected.value.errors == "service unavailable"
+
+
+class TestIsExist:
+    """Tests for function is_exist"""
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_normal_flow(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.exists.return_value = True
+
+        test_handler = GCSHandler("test_bucket_name")
+        result = test_handler.is_exist("test_file_name")
+        assert result is True
+        mock_bucket.blob.assert_called_once()
+        mock_blob.exists.assert_called_once()
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_succeed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.exists.side_effect = [ServiceUnavailable("service unavailable"), True]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        result = test_handler.is_exist("test_file_name")
+        assert result is True
+        assert mock_bucket.blob.call_count == 2
+        assert mock_blob.exists.call_count == 2
+
+    @patch("styler_rest_framework.helpers.gcs_handler.storage.Client", autospec=True)
+    def test_retry_failed(self, mock_gcs):
+        mock_client = mock_gcs.return_value
+        mock_client.get_bucket = MagicMock()
+        mock_bucket = mock_client.get_bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.exists.side_effect = [
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+            ServiceUnavailable("service unavailable"),
+        ]
+
+        test_handler = GCSHandler("test_bucket_name", back_off=0.1)
+        with pytest.raises(ServiceUnavailable) as expected:
+            test_handler.is_exist("test_file_name")
+            assert expected.value.errors == "service unavailable"


### PR DESCRIPTION
## Topic
[Move GCS handler into Styler Rest Framework](https://styler.atlassian.net/browse/STYLER-1449)

## Details
* Add `gcs_handler` in helpers folder.
* Add tests and reached 100% test coverage for new added file.